### PR TITLE
feat: add Post model to Django admin interface

### DIFF
--- a/blog/admin.py
+++ b/blog/admin.py
@@ -2,3 +2,12 @@ from django.contrib import admin
 
 # Register your models here.
 from .models import Post
+
+class PostAdmin(admin.ModelAdmin):
+    list_display = ('title', 'slug', 'status', 'created_on')
+    list_filter = ('status',)
+    search_fields = ['title', 'content']
+    prepopulated_fields = {'slug': ('title',)}
+
+
+admin.site.register(Post, PostAdmin)


### PR DESCRIPTION
Registered the Post model in Django admin for content management.

<img width="1247" height="1034" alt="django_admin" src="https://github.com/user-attachments/assets/c43c71f9-661a-42f0-80ac-87c00f7d990c" />
